### PR TITLE
Fix bug where values with capital letters lead to error

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -147,7 +147,7 @@ Parser.prototype.parseItem = function() {
   if (c.match(/[0-9\-]/)) {
     return this.parseNumber();
   }
-  if (c.match(/[a-z]/)) {
+  if (c.match(/[a-z]/i)) {
     return this.parseIdentifier();
   }
 
@@ -198,7 +198,7 @@ Parser.prototype.parseString = function() {
 
 Parser.prototype.parseIdentifier = function() {
 
-  var identifierRegex = /^[a-z][a-z0-9_\-\*\/]{0,254}/
+  var identifierRegex = /^[a-z][a-z0-9_\-\*\/]{0,254}/i;
   var result = this.input.substr(this.position).match(identifierRegex);
   if (!result) {
     throw Error('Expected identifier at position: ' + this.position);

--- a/test/parse-dictionary.js
+++ b/test/parse-dictionary.js
@@ -18,6 +18,20 @@ describe("Dictionaries", () => {
 
   });
 
+  it('should parse dictionaries with capital letters', () => {
+
+    var input = 'realm="me@example.com", algorithm=MD5';
+    var output = parse(input);
+
+    var expected = {
+      realm: 'me@example.com',
+      algorithm: 'MD5'
+    };
+
+    expect(output).to.deep.equal(expected);
+
+  });
+
   it('should fail if a dictionary key appeared twice', () => {
 
     var input = 'foo=1.23, foo="bar"';
@@ -26,7 +40,7 @@ describe("Dictionaries", () => {
     }).to.throw(Error);
 
   });
-  
+
   it('should fail on broken identifiers', () => {
 
     var input = '##=1.23, foo="bar"';


### PR DESCRIPTION
This PR fixes a bug where an unquoted string with capital letters lead to an error:

```
> const header = require('structured-header')
undefined
> header.parseDictionary('algorithm=ABC')
Error: Unexpected character: A on position 10
    at Parser.parseItem (/.../node_modules/structured-header/src/parser.js:154:9)
    at Parser.parseDictionary (/.../node_modules/structured-header/src/parser.js:25:22)
    at Object.parseDictionary (/.../node_modules/structured-header/index.js:8:19)
```