### PR TITLE
Use HTTPS repository metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+ssh://git@github.com/evert/structured-header.git"
+    "url": "git+https://github.com/badgateway/structured-headers.git"
   },
   "keywords": [
     "http",


### PR DESCRIPTION
## Summary
- replace the SSH-style repository metadata with a public HTTPS URL
- point the repository field at the current public GitHub repository after the `evert/structured-header` redirect
- keep runtime code, dependencies, package version, package contents, homepage, bugs, and license unchanged

## Reproduction
`npm view structured-headers@2.0.2 name version repository homepage bugs license --json` currently reports an SSH repository URL, which is harder for registry tooling and unauthenticated consumers to follow.

## Validation
- `node -e "const p=require('./package.json'); if (p.name !== 'structured-headers') throw new Error('wrong package'); if (p.repository.url !== 'git+https://github.com/badgateway/structured-headers.git') throw new Error('repository metadata missing'); if (p.homepage !== 'https://github.com/evert/structured-header#readme') throw new Error('homepage changed'); if (p.bugs.url !== 'https://github.com/evert/structured-header/issues') throw new Error('bugs changed'); if (p.license !== 'MIT') throw new Error('license changed'); console.log('metadata ok')"`
- `npm pack --dry-run --ignore-scripts --json .`
- `git diff --check`